### PR TITLE
errorWord를 호버 시, 다듬을 단어를 추천하는 overlay를 제작하였습니다.

### DIFF
--- a/src/pages/index/ui/index.tsx
+++ b/src/pages/index/ui/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import OverlayRecommendedBox from "@/shared/components/overlay/Box";
 import SideBar from "@/shared/components/write/sideBar/SideBar";
 
 const IndexPage = () => {
@@ -17,6 +17,7 @@ const IndexPage = () => {
     <>
       <button onClick={() => login()}>로그인</button>
       <SideBar />
+      <OverlayRecommendedBox refineWord={"따자하오"} />
     </>
   );
 };

--- a/src/pages/index/ui/index.tsx
+++ b/src/pages/index/ui/index.tsx
@@ -17,7 +17,6 @@ const IndexPage = () => {
     <>
       <button onClick={() => login()}>로그인</button>
       <SideBar />
-      <OverlayRecommendedBox refineWord={"따자하오"} />
     </>
   );
 };

--- a/src/shared/components/CKEditor/WriteHeader/index.tsx
+++ b/src/shared/components/CKEditor/WriteHeader/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import * as S from './style';
 
 const WriteHeader = () => {

--- a/src/shared/components/CKEditor/index.tsx
+++ b/src/shared/components/CKEditor/index.tsx
@@ -81,6 +81,7 @@ import {
   WordCount,
   Plugin,
 } from "ckeditor5";
+import HoverTracker from "@/shared/components/overlay/HoverTracker";
 
 import "ckeditor5/ckeditor5.css";
 
@@ -235,6 +236,7 @@ export default function CKEditorComponent() {
         try {
           const response = await fetch(`${import.meta.env.VITE_API_URL}/files/${hashed_id}`, {
             method: "GET",
+
             headers: {
               "Content-Type": "application/json",
             },
@@ -491,40 +493,43 @@ export default function CKEditorComponent() {
             <div className="editor-container__editor-wrapper">
               <div className="editor-container__editor">
                 <div>
-                  {isLayoutReady && editorConfig && (
-                    <CKEditor
-                      onReady={(editor) => {
-                        console.log("Editor is ready to use!", editor);
-                        // 에디터 인스턴스 저장
-                        editorRef.current = editor;
-                        documentManager.initDocument(editorRef);
-                        const wordCount = editor.plugins.get("WordCount");
-                        editorWordCountRef.current.appendChild(wordCount.wordCountContainer);
-                        editorToolbarRef.current.appendChild(editor.ui.view.toolbar.element);
-                        editorMenuBarRef.current.appendChild(editor.ui.view.menuBarView.element);
 
-                        CKEditorInspector.attach(editor);
-                      }}
-                      onAfterDestroy={() => {
-                        Array.from(editorWordCountRef.current.children).forEach((child) =>
-                          child.remove()
-                        );
-                        Array.from(editorToolbarRef.current.children).forEach((child) =>
-                          child.remove()
-                        );
-                        Array.from(editorMenuBarRef.current.children).forEach((child) =>
-                          child.remove()
-                        );
-                      }}
-                      editor={DecoupledEditor}
-                      config={editorConfig}
-                      onChange={(event, editor) => {
-                        // 타이머 재시작
-                        const data = editor.getData();
-                        timerRef.current.stop();
-                        timerRef.current.start(3000);
-                      }}
-                    />
+                  {isLayoutReady && editorConfig && (
+                    <HoverTracker>
+                      <CKEditor
+                        onReady={(editor) => {
+                          console.log("Editor is ready to use!", editor);
+                          // 에디터 인스턴스 저장
+                          editorRef.current = editor;
+                          documentManager.initDocument(editorRef);
+                          const wordCount = editor.plugins.get("WordCount");
+                          editorWordCountRef.current.appendChild(wordCount.wordCountContainer);
+                          editorToolbarRef.current.appendChild(editor.ui.view.toolbar.element);
+                          editorMenuBarRef.current.appendChild(editor.ui.view.menuBarView.element);
+
+                          CKEditorInspector.attach(editor);
+                        }}
+                        onAfterDestroy={() => {
+                          Array.from(editorWordCountRef.current.children).forEach((child) =>
+                            child.remove()
+                          );
+                          Array.from(editorToolbarRef.current.children).forEach((child) =>
+                            child.remove()
+                          );
+                          Array.from(editorMenuBarRef.current.children).forEach((child) =>
+                            child.remove()
+                          );
+                        }}
+                        editor={DecoupledEditor}
+                        config={editorConfig}
+                        onChange={(event, editor) => {
+                          // 타이머 재시작
+                          const data = editor.getData();
+                          timerRef.current.stop();
+                          timerRef.current.start(3000);
+                        }}
+                      />
+                    </HoverTracker>
                   )}
                   {!isLayoutReady && <div className="editor-loading">Loading editor...</div>}
                 </div>

--- a/src/shared/components/overlay/Box/index.tsx
+++ b/src/shared/components/overlay/Box/index.tsx
@@ -1,0 +1,12 @@
+import * as S from './style';
+
+const OverlayRecommendedBox = ({ refineWord }: {refineWord: string;}) => {
+  return (
+    <S.OverlayBox>
+      <S.OverlayText>이런 단어는 어때요?</S.OverlayText>
+      <S.OverlayRefineWord>{refineWord}</S.OverlayRefineWord>
+    </S.OverlayBox>
+  );
+};
+
+export default OverlayRecommendedBox;

--- a/src/shared/components/overlay/Box/index.tsx
+++ b/src/shared/components/overlay/Box/index.tsx
@@ -1,10 +1,22 @@
-import * as S from './style';
+import * as S from "./style";
 
-const OverlayRecommendedBox = ({ refineWord }: {refineWord: string;}) => {
+interface OverlayRecommendedBoxProps {
+  originId: string;
+  left: number;
+  top: number;
+}
+
+const OverlayRecommendedBox = ({
+  originId,
+  left,
+  top,
+}: OverlayRecommendedBoxProps) => {
   return (
-    <S.OverlayBox>
+    <S.OverlayBox
+      style={{ position: "relative", left: `${left}px`, top: `${top}px` }}
+    >
       <S.OverlayText>이런 단어는 어때요?</S.OverlayText>
-      <S.OverlayRefineWord>{refineWord}</S.OverlayRefineWord>
+      <S.OverlayRefineWord>{"refineWord"}</S.OverlayRefineWord>
     </S.OverlayBox>
   );
 };

--- a/src/shared/components/overlay/Box/index.tsx
+++ b/src/shared/components/overlay/Box/index.tsx
@@ -1,7 +1,8 @@
 import * as S from "./style";
+import { DocumentManager } from "@/shared/stores/DocumentManager";
 
 interface OverlayRecommendedBoxProps {
-  originId: string;
+  originId: string | undefined;
   left: number;
   top: number;
 }
@@ -11,13 +12,20 @@ const OverlayRecommendedBox = ({
   left,
   top,
 }: OverlayRecommendedBoxProps) => {
+  const documentManager = new DocumentManager();
+
+  if(!originId) return (<></>)
+  const errorDetail = documentManager.getErrorByErrorId(originId);
+
   return (
-    <S.OverlayBox
-      style={{ position: "relative", left: `${left}px`, top: `${top}px` }}
-    >
-      <S.OverlayText>이런 단어는 어때요?</S.OverlayText>
-      <S.OverlayRefineWord>{"refineWord"}</S.OverlayRefineWord>
-    </S.OverlayBox>
+    originId && (
+      <S.OverlayBox
+        style={{ position: "relative", left: `${left - 10}px`, top: `${top - 50}px` }}
+      >
+        <S.OverlayText>이런 단어는 어때요?</S.OverlayText>
+        <S.OverlayRefineWord>{errorDetail?.refine_word.join(', ')}</S.OverlayRefineWord>
+      </S.OverlayBox>
+    )
   );
 };
 

--- a/src/shared/components/overlay/Box/style.ts
+++ b/src/shared/components/overlay/Box/style.ts
@@ -1,0 +1,27 @@
+import styled from "styled-components";
+
+export const OverlayBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  border-radius: 10px;
+  border: 0.2px solid #a5e4cd;
+  background: #fff;
+  box-shadow: 2px 3px 8px 0px rgba(5, 165, 105, 0.1);
+  width: fit-content;
+  padding: 4px 8px;
+`;
+
+export const OverlayText = styled.span`
+  color: #2b2b2b;
+  font-size: 12px;
+`
+
+export const OverlayRefineWord = styled.mark`
+  color: #05A569;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 19.2px;
+  background: rgba(5, 165, 105, 0.14);
+`

--- a/src/shared/components/overlay/HoverTracker/index.tsx
+++ b/src/shared/components/overlay/HoverTracker/index.tsx
@@ -1,0 +1,16 @@
+import React, { useCallback, useRef } from 'react';
+
+export default function HoverTracker({ children }: { children: React.ReactNode }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseOver = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    console.log('Hovered element tag:', target.tagName);
+  }, []);
+
+  return (
+    <div ref={containerRef} onMouseOver={handleMouseOver}>
+      {children}
+    </div>
+  );
+}

--- a/src/shared/components/overlay/HoverTracker/index.tsx
+++ b/src/shared/components/overlay/HoverTracker/index.tsx
@@ -1,15 +1,54 @@
-import React, { useCallback, useRef } from 'react';
+import OverlayRecommendedBox from "../Box";
+import * as S from "./style";
+import React, { useCallback, useRef, useState } from "react";
 
-export default function HoverTracker({ children }: { children: React.ReactNode }) {
+export default function HoverTracker({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   const containerRef = useRef<HTMLDivElement>(null);
 
+  const [originId, setOriginId] = useState<string | null>(null);
+  const [targetPosition, setTargetPosition] = useState({
+    top: 0,
+    left: 0,
+  });
   const handleMouseOver = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     const target = e.target as HTMLElement;
-    console.log('Hovered element tag:', target.tagName);
+    const originId = target.attributes.getNamedItem("originid")?.value;
+
+    if (originId) {
+      console.log("Hovered element originId:", originId);
+      const containerRect = containerRef.current?.getBoundingClientRect();
+      const targetRect = target.getBoundingClientRect();
+      let rect = { top: 0, left: 0 };
+
+      if (containerRect) {
+        rect = {
+          top: targetRect.top - containerRect.top,
+          left: targetRect.left - containerRect.left,
+        };
+      }
+      setTargetPosition({ top: rect.top, left: rect.left });
+      setOriginId(originId);
+    } else {
+      setTargetPosition({ top: 0, left: 0 });
+      setOriginId(null);
+    }
   }, []);
 
   return (
     <div ref={containerRef} onMouseOver={handleMouseOver}>
+      <S.Overlay>
+        {!!originId && (
+          <OverlayRecommendedBox
+            left={targetPosition.left}
+            top={targetPosition.top}
+            originId={originId}
+          />
+        )}
+      </S.Overlay>
       {children}
     </div>
   );

--- a/src/shared/components/overlay/HoverTracker/index.tsx
+++ b/src/shared/components/overlay/HoverTracker/index.tsx
@@ -8,12 +8,12 @@ export default function HoverTracker({
   children: React.ReactNode;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
-
-  const [originId, setOriginId] = useState<string | null>(null);
+  const [originId, setOriginId] = useState<string | undefined>(undefined);
   const [targetPosition, setTargetPosition] = useState({
     top: 0,
     left: 0,
   });
+  
   const handleMouseOver = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     const target = e.target as HTMLElement;
     const originId = target.attributes.getNamedItem("originid")?.value;
@@ -22,6 +22,7 @@ export default function HoverTracker({
       console.log("Hovered element originId:", originId);
       const containerRect = containerRef.current?.getBoundingClientRect();
       const targetRect = target.getBoundingClientRect();
+
       let rect = { top: 0, left: 0 };
 
       if (containerRect) {
@@ -30,24 +31,24 @@ export default function HoverTracker({
           left: targetRect.left - containerRect.left,
         };
       }
-      setTargetPosition({ top: rect.top, left: rect.left });
-      setOriginId(originId);
-    } else {
-      setTargetPosition({ top: 0, left: 0 });
-      setOriginId(null);
+      setTargetPosition({
+        top: rect.top,
+        left: rect.left,
+      });
     }
+
+    setOriginId(originId);
+
   }, []);
 
   return (
     <div ref={containerRef} onMouseOver={handleMouseOver}>
       <S.Overlay>
-        {!!originId && (
-          <OverlayRecommendedBox
-            left={targetPosition.left}
-            top={targetPosition.top}
-            originId={originId}
-          />
-        )}
+        <OverlayRecommendedBox
+          left={targetPosition.left}
+          top={targetPosition.top}
+          originId={originId}
+        />
       </S.Overlay>
       {children}
     </div>

--- a/src/shared/components/overlay/HoverTracker/style.ts
+++ b/src/shared/components/overlay/HoverTracker/style.ts
@@ -1,0 +1,6 @@
+import styled from "styled-components";
+
+export const Overlay = styled.div`
+  position: absolute;
+  z-index: 2;
+`;

--- a/src/shared/services/DocumentService.ts
+++ b/src/shared/services/DocumentService.ts
@@ -186,4 +186,13 @@ export class DocumentService {
   public getResolvedErrors(): ReadonlyArray<ErrorDetail> {
     return this.errorParagraphsRepository.getResolvedErrors();
   }
+
+    /**
+   * 외래어를 Error Id로 검색합니다.
+   * @param error_id 외래어 단락의 Error Id
+   * @returns 외래어 단락 정보 (없으면 undefined)
+   */
+  public getErrorByErrorId(error_id: string): ErrorDetail | undefined {
+    return this.errorParagraphsRepository.getErrorByErrorId(error_id);
+  }
 }

--- a/src/shared/services/ErrorParagraphsRepository.ts
+++ b/src/shared/services/ErrorParagraphsRepository.ts
@@ -121,6 +121,22 @@ export class ErrorParagraphsRepository {
     );
   }
 
+  /**
+   * 외래어를 Error Id로 검색합니다.
+   * @param error_id 외래어 단락의 Error Id
+   * @returns 외래어 단락 정보 (없으면 undefined)
+   */
+  public getErrorByErrorId(error_id: string): ErrorDetail | undefined {
+    let foundError: ErrorDetail | undefined = undefined;
+    Array.from(this.errorParagraphsMap.values()).forEach((errorParagraph) => {
+      const error = errorParagraph.errors.find((e) => e.error_id === error_id);
+      if (error) {
+        foundError = error;
+      }
+    });
+    return foundError;
+  }
+
   // For React
   /**
    * 외래어 단락 목록 업데이트 시 호출될 콜백 함수의 배열입니다.

--- a/src/shared/stores/DocumentManager.ts
+++ b/src/shared/stores/DocumentManager.ts
@@ -111,4 +111,13 @@ export class DocumentManager {
   public getResolvedErrors(): ReadonlyArray<ErrorDetail> {
     return DocumentManager.documentService.getResolvedErrors();
   }
+
+    /**
+   * 외래어를 Error Id로 검색합니다.
+   * @param error_id 외래어 단락의 Error Id
+   * @returns 외래어 단락 정보 (없으면 undefined)
+   */
+  public getErrorByErrorId(error_id: string): ErrorDetail | undefined {
+    return DocumentManager.documentService.getErrorByErrorId(error_id);
+  }
 }


### PR DESCRIPTION
## 💡 개요
errorWord를 호버`(onMouseOver)`될 시, 다듬을 단어를 추천하는 overlay를 제작하였습니다.

## 📃 작업내용
`HoverTracker` 컴포넌트를 통해 `children` 컴포넌트 산하의 태그 중 mouseOver된 태그의 정보`(id, top, left)`를 추출하여
`DocumentManager`를 통해 다듬을 단어 목록에서 `id`(origin_id)와 일치하는 `refind_word`를 오버레이에 표시하는 로직을 제작하였습니다.

## 🔀 변경사항
`-`

## 📸 스크린샷
![스크린샷 2025-04-18 오후 11 38 59](https://github.com/user-attachments/assets/9b0a760a-a639-474b-81ef-b23a7e2b8860)
