### PR TITLE
Feat/nara 24 replace preview

### DIFF
--- a/src/shared/components/write/sideBar/SideBar.tsx
+++ b/src/shared/components/write/sideBar/SideBar.tsx
@@ -9,8 +9,13 @@ const error_description = ["", "불필요한 외래어 사용"];
 export default function SideBar() {
   const documentManager = React.useMemo(() => new DocumentManager(), []);
   const [selectedErrorId, setSelectedErrorId] = useState("");
-  const [errorParagraphs, setErrorParagraphs] = useState(documentManager.getErrorParagraphs());
-  const [resolvedErrors, setResolvedErrors] = useState(documentManager.getResolvedErrors());
+  const [errorParagraphs, setErrorParagraphs] = useState(
+    documentManager.getErrorParagraphs()
+  );
+  const [resolvedErrors, setResolvedErrors] = useState(
+    documentManager.getResolvedErrors()
+  );
+
   React.useEffect(() => {
     console.log("subscription");
     const unsubscribe = documentManager.subscribe(() => {
@@ -40,10 +45,12 @@ export default function SideBar() {
                   <OpenListItem
                     key={error.error_id}
                     errorDetail={error}
+                    target_id={errorsInParagraph.target_id}
                     description={error_description[error.code]}
                     error_id={error.error_id}
                     onClick={(e: React.MouseEvent<HTMLDivElement>) => {
-                      if ((e.target as HTMLElement).tagName === "BUTTON") return;
+                      if ((e.target as HTMLElement).tagName === "BUTTON")
+                        return;
                       setSelectedErrorId("");
                     }}
                   />
@@ -62,7 +69,12 @@ export default function SideBar() {
             ));
           })}
           {resolvedErrors.map((resolvedError) => {
-            return <RefinedItem key={resolvedError.error_id} errorDetail={resolvedError} />;
+            return (
+              <RefinedItem
+                key={resolvedError.error_id}
+                errorDetail={resolvedError}
+              />
+            );
           })}
         </SideBarMain>
       </SideBarBox>

--- a/src/shared/components/write/sideBar/list/OpenListItem.tsx
+++ b/src/shared/components/write/sideBar/list/OpenListItem.tsx
@@ -3,13 +3,16 @@ import loanword from "/public/images/icon/loanword.svg";
 import * as All from "./ErrorListItem";
 import { DocumentManager } from "@/shared/stores/DocumentManager";
 import { ErrorDetail } from "@/shared/stores/error";
+import { useEffect, useState } from "react";
+import getSurroundingWordsByOriginId from "@/utils/getSurroundingWordsByOriginId";
 
 const documentManager = new DocumentManager();
 interface OpenListItemProps {
   errorDetail: ErrorDetail;
   description: string;
   onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
-  error_id?: string;
+  error_id: string;
+  target_id: string;
 }
 
 export default function OpenListItem({
@@ -17,7 +20,23 @@ export default function OpenListItem({
   description,
   onClick,
   error_id,
+  target_id,
 }: OpenListItemProps) {
+  const [surroundingWords, setSurroundingWords] = useState({
+    after: "",
+    before: "",
+  });
+
+  useEffect(() => {
+    const { after, before } = getSurroundingWordsByOriginId(
+      target_id,
+      error_id,
+      3
+    );
+    console.log(after, before);
+    setSurroundingWords({ after: after.join(" "), before: before.join(" ") });
+  }, []);
+
   return (
     <>
       <OpenListItemBox onClick={onClick}>
@@ -28,15 +47,16 @@ export default function OpenListItem({
             <All.ContextBox>
               <All.Description>{description}</All.Description>
               <All.Text>
-                {errorDetail.origin_word} → <RefinedText>{errorDetail.refine_word[0]}</RefinedText>
+                {errorDetail.origin_word} →{" "}
+                <RefinedText>{errorDetail.refine_word[0]}</RefinedText>
               </All.Text>
             </All.ContextBox>
           </All.ListContentBox>
           <RefineBox>
-            <RefineTest>나는 이 일을</RefineTest>
+            <RefineTest>{surroundingWords.before}</RefineTest>
             <DeleteText>{errorDetail.origin_word}</DeleteText>
             <RefinedText>{errorDetail.refine_word[0]}</RefinedText>
-            <RefineTest>할 수 있어</RefineTest>
+            <RefineTest>{surroundingWords.after}</RefineTest>
           </RefineBox>
           <Buttons>
             <RefineButton>
@@ -99,7 +119,7 @@ const RefineBox = styled.div`
   padding: 4px 8px;
   justify-content: center;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   border-radius: 4px;
   background: #f8fbfc;
 `;

--- a/src/utils/getSurroundingWordsByOriginId.ts
+++ b/src/utils/getSurroundingWordsByOriginId.ts
@@ -1,0 +1,25 @@
+export default function getSurroundingWordsByOriginId(targetId : string, originId : string, count = 3) {
+  const editor = document.querySelectorAll(".ck-content")[0];
+
+  const p = editor.querySelector(`p[data-unique="${targetId}"]`);
+
+  if (!p) return { before: [], after: [] };
+  const clone = p.cloneNode(true) as Element;
+
+  const span = clone.querySelector(`span[originid="${originId}"]`);
+  if (!span) return { before: [], after: [] };
+
+  const MARKER = '<<<>>>';
+  span.replaceWith(MARKER);
+  const textContent = clone.textContent;
+  if (!textContent) return { before: [], after: [] };
+
+  const tokens = textContent.replace(MARKER, ` ${MARKER} `).trim().split(/\s+/);
+  const idx = tokens.indexOf(MARKER);
+  if (idx < 0) return { before: [], after: [] };
+
+  return {
+    before: tokens.slice(Math.max(0, idx - count), idx),
+    after: tokens.slice(idx + 1, idx + 1 + count),
+  };
+}

--- a/src/utils/getSurroundingWordsByOriginId.ts
+++ b/src/utils/getSurroundingWordsByOriginId.ts
@@ -1,6 +1,7 @@
 export default function getSurroundingWordsByOriginId(targetId : string, originId : string, count = 3) {
-  const editor = document.querySelectorAll(".ck-content")[0];
-
+  const editors = document.querySelectorAll(".ck-content");
+  if (editors.length === 0) return { before: [], after: [] };
+  const editor = editors[0];
   const p = editor.querySelector(`p[data-unique="${targetId}"]`);
 
   if (!p) return { before: [], after: [] };


### PR DESCRIPTION
## 💡 개요
다듬을 시 문장이 어떻게 바뀌는 지를 표시하는 **preview**를 개발하였습니다.

## 📃 작업내용
- `getSurroundingWordsByOriginId`에서 `targetId, originId`를 받아 처리합니다.
  1. `targeId`로 p태그를 `data-unique`로 추적합니다.
  2. 추적한 p태그 내에서 span(error)를 `origin_id`로 추적합니다.
  3. 추적한 span를 MARKER로 치환합니다.
  4. p태그 string을 어절 단위로 split하여 MARKER 전과 후 `count` 갯수 만큼 추출하여 
  `before`과 `after`로 반홥니다.
- `OpenListItem`에 `before`과 `after`를 바인딩합니다.

## 🔀 변경사항
`-`
## 📸 스크린샷
![스크린샷 2025-04-19 오후 10 54 50](https://github.com/user-attachments/assets/ec959c6b-3c81-4f73-b443-bfc19eaf830d)
