### PR TITLE
Feat/nara 27 scroll

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -32,3 +32,9 @@ body {
 #root > div > div > section > div.editor-container-section > div.editor-container__editor-wrapper {
 	height: 100%;
 }
+
+.main-container {
+	position: fixed;
+	top: 0;
+	left: 0;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,14 +1,34 @@
-@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css");
-@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&display=swap");
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&display=swap');
 
 body {
-  margin: 0;
-  min-width: 320px;
-  min-height: 100vh;
-  font-family: "Noto Sans KR", "Pretendard", sans-serif;
+	margin: 0;
+	min-width: 320px;
+	min-height: 100vh;
+	font-family: 'Noto Sans KR', 'Pretendard', sans-serif;
 }
 
 .__origin_word__ {
-  background: rgba(255, 94, 94, 0.24);
-  border-bottom: 2px solid #FF5E5E;
+	background: rgba(255, 94, 94, 0.24);
+	border-bottom: 2px solid #ff5e5e;
+}
+
+@keyframes flash {
+	0% {
+		background: #ffe066;
+	}
+	100% {
+		background: transparent;
+	}
+}
+
+.flash-highlight {
+	animation: flash 2s ease-out forwards;
+}
+
+#root > div > div > section {
+	height: 100%;
+}
+#root > div > div > section > div.editor-container-section > div.editor-container__editor-wrapper {
+	height: 100%;
 }

--- a/src/shared/components/CKEditor/style.css
+++ b/src/shared/components/CKEditor/style.css
@@ -6,7 +6,7 @@
 	}
 }
 
-body{
+body {
 	overflow: hidden;
 }
 
@@ -81,9 +81,9 @@ body{
 	height: fit-content;
 	padding: 20mm 12mm;
 	background: hsl(0, 0%, 100%);
-	flex: 1 1 auto;
+	/* flex: 1 1 auto;
 	margin-left: 72px;
-	margin-right: 72px;
+	margin-right: 72px; */
 }
 
 .ck.ck-editor__editable:hover {
@@ -111,7 +111,7 @@ body{
 	box-shadow: none !important;
 }
 
-.editor-container__menu-bar > div{
+.editor-container__menu-bar > div {
 	gap: 1.5rem !important;
 }
 

--- a/src/shared/components/write/sideBar/SideBar.tsx
+++ b/src/shared/components/write/sideBar/SideBar.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import TabsBlock from './tabs/TabsBlock';
 import ListItem from './list/ErrorListItem';
 import OpenListItem from './list/OpenListItem';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { DocumentManager } from '@/shared/stores/DocumentManager';
 import RefinedItem from './list/RefinedItem';
 const error_description = ['', '불필요한 외래어 사용'];
@@ -14,6 +14,11 @@ export default function SideBar() {
 	const [selectedErrorId, setSelectedErrorId] = useState('');
 	const [errorParagraphs, setErrorParagraphs] = useState(documentManager.getErrorParagraphs());
 	const [resolvedErrors, setResolvedErrors] = useState(documentManager.getResolvedErrors());
+
+	const prevRef = useRef<{ el: HTMLElement | null; timer: number | null }>({
+		el: null,
+		timer: null,
+	});
 
 	React.useEffect(() => {
 		console.log('subscription');
@@ -36,18 +41,24 @@ export default function SideBar() {
 	React.useEffect(() => {
 		if (!selectedErrorId) return;
 		const container = document.querySelector<HTMLElement>(EDITOR_CONTAINER_SELECTOR);
-		const target = document.querySelector<HTMLElement>(`span[originid="${selectedErrorId}"], span[refineid="${selectedErrorId}"]`);
-		if (!container || !target) return;
+		if (!container) return;
+		const target = container.querySelector<HTMLElement>(`span[originid="${selectedErrorId}"], span[refineid="${selectedErrorId}"]`);
+		if (!target) return;
+
+		if (prevRef.current.timer) clearTimeout(prevRef.current.timer);
+		if (prevRef.current.el && prevRef.current.el !== target) {
+			prevRef.current.el.classList.remove('flash-highlight');
+		}
 
 		const targetOffset = target.offsetTop - container.offsetTop - container.clientHeight / 2 + target.clientHeight / 2;
 		container.scrollTo({ top: targetOffset, behavior: 'smooth' });
 
 		target.classList.add('flash-highlight');
-		const timer = setTimeout(() => {
+		const timer = window.setTimeout(() => {
 			target.classList.remove('flash-highlight');
 		}, HIGHLIGHT_DURATION);
 
-		return () => clearTimeout(timer);
+		prevRef.current = { el: target, timer };
 	}, [selectedErrorId]);
 	return (
 		<React.Fragment>

--- a/src/shared/components/write/sideBar/SideBar.tsx
+++ b/src/shared/components/write/sideBar/SideBar.tsx
@@ -60,6 +60,16 @@ export default function SideBar() {
 
 		prevRef.current = { el: target, timer };
 	}, [selectedErrorId]);
+
+	React.useEffect(() => {
+		return () => {
+			if (prevRef.current.timer) clearTimeout(prevRef.current.timer);
+			if (prevRef.current.el) {
+				prevRef.current.el.classList.remove('flash-highlight');
+			}
+		};
+	}, []);
+
 	return (
 		<React.Fragment>
 			<SideBarBox>

--- a/src/shared/components/write/sideBar/SideBar.tsx
+++ b/src/shared/components/write/sideBar/SideBar.tsx
@@ -36,7 +36,7 @@ export default function SideBar() {
 	React.useEffect(() => {
 		if (!selectedErrorId) return;
 		const container = document.querySelector<HTMLElement>(EDITOR_CONTAINER_SELECTOR);
-		const target = document.querySelector<HTMLSpanElement>(`span[originid="${selectedErrorId}"]`);
+		const target = document.querySelector<HTMLElement>(`span[originid="${selectedErrorId}"], span[refineid="${selectedErrorId}"]`);
 		if (!container || !target) return;
 
 		const targetOffset = target.offsetTop - container.offsetTop - container.clientHeight / 2 + target.clientHeight / 2;
@@ -84,7 +84,15 @@ export default function SideBar() {
 						));
 					})}
 					{resolvedErrors.map((resolvedError) => {
-						return <RefinedItem key={resolvedError.error_id} errorDetail={resolvedError} />;
+						return (
+							<RefinedItem
+								key={resolvedError.error_id}
+								errorDetail={resolvedError}
+								onClick={() => {
+									setSelectedErrorId(resolvedError.error_id);
+								}}
+							/>
+						);
 					})}
 				</SideBarMain>
 			</SideBarBox>

--- a/src/shared/components/write/sideBar/SideBar.tsx
+++ b/src/shared/components/write/sideBar/SideBar.tsx
@@ -9,19 +9,6 @@ const error_description = ['', '불필요한 외래어 사용'];
 export default function SideBar() {
 	const HIGHLIGHT_DURATION = 2000;
 	const EDITOR_CONTAINER_SELECTOR = '.editor-container__editor-wrapper';
-  const documentManager = React.useMemo(() => new DocumentManager(), []);
-  const [selectedErrorId, setSelectedErrorId] = useState("");
-  const [errorParagraphs, setErrorParagraphs] = useState(
-    documentManager.getErrorParagraphs()
-  );
-
-  const count = errorParagraphs.reduce((acc, cur) => {
-    return acc + cur.errors.length;
-  }, 0);
-
-  const [resolvedErrors, setResolvedErrors] = useState(
-    documentManager.getResolvedErrors()
-  );
 
 	const documentManager = React.useMemo(() => new DocumentManager(), []);
 	const [selectedErrorId, setSelectedErrorId] = useState('');
@@ -33,6 +20,10 @@ export default function SideBar() {
 		el: null,
 		timer: null,
 	});
+
+	const count = errorParagraphs.reduce((acc, cur) => {
+		return acc + cur.errors.length;
+	}, 0);
 
 	React.useEffect(() => {
 		console.log('subscription');

--- a/src/shared/components/write/sideBar/SideBar.tsx
+++ b/src/shared/components/write/sideBar/SideBar.tsx
@@ -12,6 +12,7 @@ export default function SideBar() {
 
 	const documentManager = React.useMemo(() => new DocumentManager(), []);
 	const [selectedErrorId, setSelectedErrorId] = useState('');
+	const [flashTick, setFlashTick] = useState(0);
 	const [errorParagraphs, setErrorParagraphs] = useState(documentManager.getErrorParagraphs());
 	const [resolvedErrors, setResolvedErrors] = useState(documentManager.getResolvedErrors());
 
@@ -46,7 +47,7 @@ export default function SideBar() {
 		if (!target) return;
 
 		if (prevRef.current.timer) clearTimeout(prevRef.current.timer);
-		if (prevRef.current.el && prevRef.current.el !== target) {
+		if (prevRef.current.el) {
 			prevRef.current.el.classList.remove('flash-highlight');
 		}
 
@@ -59,7 +60,7 @@ export default function SideBar() {
 		}, HIGHLIGHT_DURATION);
 
 		prevRef.current = { el: target, timer };
-	}, [selectedErrorId]);
+	}, [selectedErrorId, flashTick]);
 
 	React.useEffect(() => {
 		return () => {
@@ -97,6 +98,7 @@ export default function SideBar() {
 										description={error_description[error.code]}
 										onClick={() => {
 											setSelectedErrorId(error.error_id);
+											setFlashTick((t) => t + 1);
 										}}
 									/>
 								)}
@@ -111,6 +113,7 @@ export default function SideBar() {
 								errorDetail={resolvedError}
 								onClick={() => {
 									setSelectedErrorId(resolvedError.error_id);
+									setFlashTick((t) => t + 1);
 								}}
 							/>
 						);

--- a/src/shared/components/write/sideBar/SideBar.tsx
+++ b/src/shared/components/write/sideBar/SideBar.tsx
@@ -1,102 +1,112 @@
-import styled from "styled-components";
-import TabsBlock from "./tabs/TabsBlock";
-import ListItem from "./list/ErrorListItem";
-import OpenListItem from "./list/OpenListItem";
-import React, { useState } from "react";
-import { DocumentManager } from "@/shared/stores/DocumentManager";
-import RefinedItem from "./list/RefinedItem";
-const error_description = ["", "불필요한 외래어 사용"];
+import styled from 'styled-components';
+import TabsBlock from './tabs/TabsBlock';
+import ListItem from './list/ErrorListItem';
+import OpenListItem from './list/OpenListItem';
+import React, { useState } from 'react';
+import { DocumentManager } from '@/shared/stores/DocumentManager';
+import RefinedItem from './list/RefinedItem';
+const error_description = ['', '불필요한 외래어 사용'];
 export default function SideBar() {
-  const documentManager = React.useMemo(() => new DocumentManager(), []);
-  const [selectedErrorId, setSelectedErrorId] = useState("");
-  const [errorParagraphs, setErrorParagraphs] = useState(
-    documentManager.getErrorParagraphs()
-  );
-  const [resolvedErrors, setResolvedErrors] = useState(
-    documentManager.getResolvedErrors()
-  );
+	const HIGHLIGHT_DURATION = 2000;
+	const EDITOR_CONTAINER_SELECTOR = '.editor-container__editor-wrapper';
 
-  React.useEffect(() => {
-    console.log("subscription");
-    const unsubscribe = documentManager.subscribe(() => {
-      console.log("event");
-      setErrorParagraphs(documentManager.getErrorParagraphs());
-      setResolvedErrors(documentManager.getResolvedErrors());
-    });
-    return () => {
-      console.log("unsubscribe");
-      unsubscribe();
-    };
-  }, [documentManager]);
+	const documentManager = React.useMemo(() => new DocumentManager(), []);
+	const [selectedErrorId, setSelectedErrorId] = useState('');
+	const [errorParagraphs, setErrorParagraphs] = useState(documentManager.getErrorParagraphs());
+	const [resolvedErrors, setResolvedErrors] = useState(documentManager.getResolvedErrors());
 
-  React.useEffect(() => {
-    console.log(`errorParagraphs Updated:`, errorParagraphs);
-    console.log(`resolvedErrors Updated:`, resolvedErrors);
-  }, [errorParagraphs, resolvedErrors]);
-  return (
-    <React.Fragment>
-      <SideBarBox>
-        <TabsBlock />
-        <SideBarMain>
-          {errorParagraphs.map((errorsInParagraph) => {
-            return errorsInParagraph.errors.map((error) => (
-              <div key={error.error_id}>
-                {error.error_id === selectedErrorId ? (
-                  <OpenListItem
-                    key={error.error_id}
-                    errorDetail={error}
-                    target_id={errorsInParagraph.target_id}
-                    description={error_description[error.code]}
-                    error_id={error.error_id}
-                    onClick={(e: React.MouseEvent<HTMLDivElement>) => {
-                      if ((e.target as HTMLElement).tagName === "BUTTON")
-                        return;
-                      setSelectedErrorId("");
-                    }}
-                  />
-                ) : (
-                  <ListItem
-                    key={error.error_id}
-                    default={error.origin_word}
-                    description={error_description[error.code]}
-                    onClick={() => {
-                      setSelectedErrorId(error.error_id);
-                    }}
-                  />
-                )}
-                <Spacer />
-              </div>
-            ));
-          })}
-          {resolvedErrors.map((resolvedError) => {
-            return (
-              <RefinedItem
-                key={resolvedError.error_id}
-                errorDetail={resolvedError}
-              />
-            );
-          })}
-        </SideBarMain>
-      </SideBarBox>
-    </React.Fragment>
-  );
+	React.useEffect(() => {
+		console.log('subscription');
+		const unsubscribe = documentManager.subscribe(() => {
+			console.log('event');
+			setErrorParagraphs(documentManager.getErrorParagraphs());
+			setResolvedErrors(documentManager.getResolvedErrors());
+		});
+		return () => {
+			console.log('unsubscribe');
+			unsubscribe();
+		};
+	}, [documentManager]);
+
+	React.useEffect(() => {
+		console.log(`errorParagraphs Updated:`, errorParagraphs);
+		console.log(`resolvedErrors Updated:`, resolvedErrors);
+	}, [errorParagraphs, resolvedErrors]);
+
+	React.useEffect(() => {
+		if (!selectedErrorId) return;
+		const container = document.querySelector<HTMLElement>(EDITOR_CONTAINER_SELECTOR);
+		const target = document.querySelector<HTMLSpanElement>(`span[originid="${selectedErrorId}"]`);
+		if (!container || !target) return;
+
+		const targetOffset = target.offsetTop - container.offsetTop - container.clientHeight / 2 + target.clientHeight / 2;
+		container.scrollTo({ top: targetOffset, behavior: 'smooth' });
+
+		target.classList.add('flash-highlight');
+		const timer = setTimeout(() => {
+			target.classList.remove('flash-highlight');
+		}, HIGHLIGHT_DURATION);
+
+		return () => clearTimeout(timer);
+	}, [selectedErrorId]);
+	return (
+		<React.Fragment>
+			<SideBarBox>
+				<TabsBlock />
+				<SideBarMain>
+					{errorParagraphs.map((errorsInParagraph) => {
+						return errorsInParagraph.errors.map((error) => (
+							<div key={error.error_id}>
+								{error.error_id === selectedErrorId ? (
+									<OpenListItem
+										key={error.error_id}
+										errorDetail={error}
+										target_id={errorsInParagraph.target_id}
+										description={error_description[error.code]}
+										error_id={error.error_id}
+										onClick={(e: React.MouseEvent<HTMLDivElement>) => {
+											if ((e.target as HTMLElement).tagName === 'BUTTON') return;
+											setSelectedErrorId('');
+										}}
+									/>
+								) : (
+									<ListItem
+										key={error.error_id}
+										default={error.origin_word}
+										description={error_description[error.code]}
+										onClick={() => {
+											setSelectedErrorId(error.error_id);
+										}}
+									/>
+								)}
+								<Spacer />
+							</div>
+						));
+					})}
+					{resolvedErrors.map((resolvedError) => {
+						return <RefinedItem key={resolvedError.error_id} errorDetail={resolvedError} />;
+					})}
+				</SideBarMain>
+			</SideBarBox>
+		</React.Fragment>
+	);
 }
 
 const SideBarBox = styled.div`
-  width: 100%;
-  max-width: 30dvw;
-  max-height: 100%;
-  border-left: 1px solid #e2e2e2;
-  background: #fff;
+	width: 100%;
+	max-width: 30dvw;
+	max-height: 100%;
+	border-left: 1px solid #e2e2e2;
+	background: #fff;
 `;
 
 const SideBarMain = styled.main`
-  border-top: 1px solid #e2e2e2;
-  overflow-y: auto;
-  height: 100%;
+	border-top: 1px solid #e2e2e2;
+	overflow-y: auto;
+	height: 100%;
 `;
 
 const Spacer = styled.hr`
-  border: 1px solid #e2e2e2;
-  margin: 0px;
+	border: 1px solid #e2e2e2;
+	margin: 0px;
 `;

--- a/src/shared/components/write/sideBar/list/RefinedItem.tsx
+++ b/src/shared/components/write/sideBar/list/RefinedItem.tsx
@@ -1,52 +1,53 @@
-import styled from "styled-components";
-import success from "/public/images/icon/success.svg";
-import * as All from "./ErrorListItem";
-import { ErrorDetail } from "@/shared/stores/error";
+import styled from 'styled-components';
+import success from '/public/images/icon/success.svg';
+import * as All from './ErrorListItem';
+import { ErrorDetail } from '@/shared/stores/error';
 
 interface RefinedItemProps {
-  errorDetail: ErrorDetail;
+	errorDetail: ErrorDetail;
+	onClick?: () => void;
 }
 
-export default function RefinedItem({ errorDetail }: RefinedItemProps) {
-  return (
-    <>
-      <RefinedItemBox>
-        <ListContentBox>
-          <Success src={success} alt="success" />
-          <All.ContextBox>
-            <All.Description>수정한 단어</All.Description>
-            <All.Text>
-              {errorDetail.origin_word} → <RefinedText>{errorDetail.refine_word[0]}</RefinedText>
-            </All.Text>
-          </All.ContextBox>
-        </ListContentBox>
-      </RefinedItemBox>
-    </>
-  );
+export default function RefinedItem({ errorDetail, onClick }: RefinedItemProps) {
+	return (
+		<>
+			<RefinedItemBox onClick={onClick}>
+				<ListContentBox>
+					<Success src={success} alt="success" />
+					<All.ContextBox>
+						<All.Description>수정한 단어</All.Description>
+						<All.Text>
+							{errorDetail.origin_word} → <RefinedText>{errorDetail.refine_word[0]}</RefinedText>
+						</All.Text>
+					</All.ContextBox>
+				</ListContentBox>
+			</RefinedItemBox>
+		</>
+	);
 }
 
 const RefinedItemBox = styled.div`
-  display: flex;
-  width: 100%;
-  padding: 10px 6px 10px 10px;
-  align-items: flex-start;
-  gap: 10px;
-  background: #fff;
+	display: flex;
+	width: 100%;
+	padding: 10px 6px 10px 10px;
+	align-items: flex-start;
+	gap: 10px;
+	background: #fff;
 `;
 
 const ListContentBox = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 12px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	gap: 12px;
 `;
 
 const RefinedText = styled(All.Text)`
-  color: #05a569;
+	color: #05a569;
 `;
 
 const Success = styled.img`
-  width: 26px;
-  height: 26px;
-  user-select: none;
+	width: 26px;
+	height: 26px;
+	user-select: none;
 `;


### PR DESCRIPTION
- 스크롤 되지 않던 버그를 고쳤습니다.
- 감지된 외래어, 수정된 단어를 사이드바에서 클릭 시 문서에서 해당 위치로 스크롤(이동)됩니다. 
- 노란색 하이라이팅(2초간 반짝임)을 통해 사이드바의 단어가 해당 위치에 있음을 알립니다.
- 하이라이팅(2초간 반짝임)이 끝나기 전에 다른 단어를 클릭하여도 하이라이팅이 누락되지 않습니다.
- 같은 단어 클릭 시 하이라이팅이 적용되지 않는 문제 해결